### PR TITLE
Add base project docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Node.js
+node_modules/
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Next.js
+.next/
+out/
+
+# Supabase
+.supabase/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE settings
+.vscode/
+
+# Operating system files
+.DS_Store
+Thumbs.db
+
+# Vercel
+.vercel/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Project Pilot
+
+Project Pilot is an AI-native platform that helps developers build software incrementally. It guides users through a phase-by-phase workflow—Planning, Core Logic, Testing and Deployment—while generating documentation and prompt packs tuned for tools like ChatGPT Codex, Claude and Cursor.
+
+The repository includes two key documents that describe the vision and minimal viable product (MVP):
+
+- [`projectdescription.md`](projectdescription.md) – High level overview and philosophy of Project Pilot.
+- [`mvp_prd.md`](mvp_prd.md) – Product requirements for the v0.1 MVP release.
+
+## Prerequisites
+
+This project is expected to run on a Next.js + Supabase stack. To work with the code you should have:
+
+- Node.js 18 or later
+- pnpm or npm for installing dependencies
+- Access to a Supabase project
+- API keys for any integrated AI services (see `apikeys.txt` as a placeholder)
+
+After cloning, install dependencies and set up your environment variables in a local `.env` file before running the development server.
+


### PR DESCRIPTION
## Summary
- document project purpose and prerequisites in README
- add Node/Next.js/Supabase `.gitignore`
- include MIT license for open source use

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684dbcd054e08320b8488d348af49cd5