### PR TITLE
Add basic planner form components

### DIFF
--- a/components/planner/ProjectCreatorForm.tsx
+++ b/components/planner/ProjectCreatorForm.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import { Input } from "../ui/input";
+import { Textarea } from "../ui/textarea";
+import { Select } from "../ui/select";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "../ui/card";
+
+export function ProjectCreatorForm() {
+  const [projectName, setProjectName] = useState("");
+  const [projectDescription, setProjectDescription] = useState("");
+  const [aiTool, setAiTool] = useState("Claude");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    console.log({ projectName, projectDescription, aiTool });
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Start a New Project</CardTitle>
+      </CardHeader>
+      <form onSubmit={handleSubmit}>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="projectName" className="mb-2 block text-sm font-medium">
+                Project Name
+              </label>
+              <Input
+                id="projectName"
+                value={projectName}
+                onChange={(e) => setProjectName(e.target.value)}
+              />
+            </div>
+            <div className="md:col-span-2">
+              <label htmlFor="projectDescription" className="mb-2 block text-sm font-medium">
+                Project Description
+              </label>
+              <Textarea
+                id="projectDescription"
+                value={projectDescription}
+                onChange={(e) => setProjectDescription(e.target.value)}
+              />
+            </div>
+            <div>
+              <label htmlFor="aiTool" className="mb-2 block text-sm font-medium">
+                AI Tool
+              </label>
+              <Select id="aiTool" value={aiTool} onChange={(e) => setAiTool(e.target.value)}>
+                <option value="Claude">Claude</option>
+                <option value="Copilot">Copilot</option>
+                <option value="Cursor">Cursor</option>
+                <option value="OpenAI">OpenAI</option>
+              </Select>
+            </div>
+          </div>
+        </CardContent>
+        <CardFooter>
+          <button
+            type="submit"
+            className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+          >
+            Create
+          </button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function Card({ className, ...props }: CardProps) {
+  return <div className={cn("rounded-lg border bg-white p-6 shadow", className)} {...props} />;
+}
+
+export interface CardHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
+export function CardHeader({ className, ...props }: CardHeaderProps) {
+  return <div className={cn("mb-4", className)} {...props} />;
+}
+
+export interface CardTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
+export function CardTitle({ className, ...props }: CardTitleProps) {
+  return <h3 className={cn("text-lg font-semibold", className)} {...props} />;
+}
+
+export interface CardContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+export function CardContent({ className, ...props }: CardContentProps) {
+  return <div className={cn("space-y-4", className)} {...props} />;
+}
+
+export interface CardFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
+export function CardFooter({ className, ...props }: CardFooterProps) {
+  return <div className={cn("mt-4", className)} {...props} />;
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...props }, ref) => {
+  return (
+    <input
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm placeholder-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  );
+});
+Input.displayName = "Input";

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(({ className, children, ...props }, ref) => {
+  return (
+    <select
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </select>
+  );
+});
+Select.displayName = "Select";

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      ref={ref}
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm placeholder-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | false | null | undefined)[]): string {
+  return classes.filter(Boolean).join(" ");
+}


### PR DESCRIPTION
## Summary
- add utility `cn` helper
- implement shadcn-style `Card`, `Input`, `Textarea`, and `Select` components
- create `ProjectCreatorForm` to start a new project

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684dc27609d48320a0ddaa4b925c2ff8