### PR TITLE
Fix README doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Project Pilot is an AI-native platform that helps developers build software incr
 
 The repository includes two key documents that describe the vision and minimal viable product (MVP):
 
-- [`ProjectPilot_Codex_ProjectDescription.md`](docs/ProjectPilot_Codex_ProjectDescription.md) – High level overview and philosophy of Project Pilot.
-- [`ProjectPilot_Mvp_Prd.md`](docs/ProjectPilot_Mvp_Prd.md) – Product requirements for the v0.1 MVP release.
+- [`docs/ProjectPilot_Codex_ProjectDescription.md`](docs/ProjectPilot_Codex_ProjectDescription.md) – High level overview and philosophy of Project Pilot.
+- [`docs/ProjectPilot_Mvp_Prd.md`](docs/ProjectPilot_Mvp_Prd.md) – Product requirements for the v0.1 MVP release.
 
 These documents shape development by framing the product vision and clarifying the MVP feature set.
 


### PR DESCRIPTION
## Summary
- update README links to include `docs/` in text

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e913cb4048320a7fd003cd5cab7e2