### PR TITLE
Add project artifacts saving helper

### DIFF
--- a/components/planner/PlanningGenerator.tsx
+++ b/components/planner/PlanningGenerator.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import { saveProjectArtifacts } from '../../lib/api/saveProjectArtifacts'
+
+interface PlanningGeneratorProps {
+  projectId: string
+}
+
+export default function PlanningGenerator({ projectId }: PlanningGeneratorProps) {
+  const [prd, setPrd] = useState('')
+  const [techStack, setTechStack] = useState('')
+  const [promptPack, setPromptPack] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSave() {
+    setSaving(true)
+    setError(null)
+    try {
+      // Save project artifacts to Supabase
+      await saveProjectArtifacts({
+        projectId,
+        prd,
+        techStack,
+        promptPack,
+      })
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <textarea
+        value={prd}
+        onChange={(e) => setPrd(e.target.value)}
+        placeholder="PRD"
+        className="w-full border rounded p-2"
+      />
+      <textarea
+        value={techStack}
+        onChange={(e) => setTechStack(e.target.value)}
+        placeholder="Tech Stack"
+        className="w-full border rounded p-2"
+      />
+      <textarea
+        value={promptPack}
+        onChange={(e) => setPromptPack(e.target.value)}
+        placeholder="Prompt Pack"
+        className="w-full border rounded p-2"
+      />
+      <button
+        onClick={handleSave}
+        disabled={saving}
+        className="rounded bg-blue-600 text-white px-4 py-2"
+      >
+        {saving ? 'Saving...' : 'Save'}
+      </button>
+      {error && <p className="text-red-500">{error}</p>}
+    </div>
+  )
+}

--- a/lib/api/saveProjectArtifacts.ts
+++ b/lib/api/saveProjectArtifacts.ts
@@ -1,0 +1,31 @@
+import { supabase } from '../supabaseClient'
+
+export interface SaveProjectArtifactsPayload {
+  projectId: string
+  prd: string
+  techStack: string
+  promptPack: string
+}
+
+export async function saveProjectArtifacts({
+  projectId,
+  prd,
+  techStack,
+  promptPack,
+}: SaveProjectArtifactsPayload) {
+  const { data, error } = await supabase
+    .from('project_artifacts')
+    .upsert(
+      { project_id: projectId, prd, tech_stack: techStack, prompt_pack: promptPack },
+      { onConflict: 'project_id' },
+    )
+    .select()
+    .single()
+
+  if (error) {
+    console.error('saveProjectArtifacts error:', error.message)
+    throw new Error(error.message)
+  }
+
+  return data
+}


### PR DESCRIPTION
## Summary
- add API helper to upsert PRD, tech stack, and prompt pack
- add PlanningGenerator component that uses the new helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684eb83ffc4c8320bbc03759add755ed