### PR TITLE
Add backend AI endpoint and client component

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 # API key for your preferred AI service (e.g. OpenAI or Anthropic)
+# Used by the API route to call OpenAI or Gemini. Do not prefix with NEXT_PUBLIC
 AI_API_KEY=your-ai-api-key

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Create a `.env` file in the project root with the following variables:
 ```bash
 NEXT_PUBLIC_SUPABASE_URL=<your-supabase-url>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-key>
-# API key for your preferred AI service (e.g. OpenAI or Anthropic)
+# API key for your preferred AI service (used server-side only)
 AI_API_KEY=<your-ai-api-key>
 ```
 

--- a/components/planner/PlanningGenerator.tsx
+++ b/components/planner/PlanningGenerator.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Textarea } from '../ui/textarea';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '../ui/card';
+import { Input } from '../ui/input';
+
+export default function PlanningGenerator() {
+  const [prompt, setPrompt] = useState('');
+  const [result, setResult] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleGenerate(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setResult('');
+    try {
+      const res = await fetch('/api/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setResult(data.text ?? '');
+      } else {
+        setResult(data.error || 'Error');
+      }
+    } catch (err) {
+      console.error(err);
+      setResult('Error generating');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Card className="mt-4">
+      <CardHeader>
+        <CardTitle>Planning Generator</CardTitle>
+      </CardHeader>
+      <form onSubmit={handleGenerate}>
+        <CardContent className="space-y-4">
+          <div>
+            <label htmlFor="prompt" className="mb-2 block text-sm font-medium">
+              Describe your project
+            </label>
+            <Textarea
+              id="prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="mb-2 block text-sm font-medium">Result</label>
+            <Textarea value={result} readOnly className="h-48" />
+          </div>
+        </CardContent>
+        <CardFooter>
+          <button
+            type="submit"
+            className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+            disabled={loading}
+          >
+            {loading ? 'Generating...' : 'Generate'}
+          </button>
+        </CardFooter>
+      </form>
+    </Card>
+  );
+}

--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { prompt } = req.body as { prompt?: string };
+  if (!prompt) {
+    return res.status(400).json({ error: 'Prompt is required' });
+  }
+
+  try {
+    const apiKey = process.env.AI_API_KEY;
+    if (!apiKey) {
+      throw new Error('AI_API_KEY not set');
+    }
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4-turbo',
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      console.error('OpenAI error:', errText);
+      return res.status(500).json({ error: 'OpenAI API error' });
+    }
+
+    const data = await response.json();
+    const text = data.choices?.[0]?.message?.content ?? '';
+    return res.status(200).json({ text });
+  } catch (err) {
+    console.error('Generation error:', err);
+    return res.status(500).json({ error: 'Failed to generate' });
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,13 @@
 import PhaseBoard from '../components/planner/PhaseBoard'
 import { ProjectCreatorForm } from '../components/planner/ProjectCreatorForm'
+import PlanningGenerator from '../components/planner/PlanningGenerator'
 
 export default function Home() {
   return (
     <main className="p-6 space-y-6">
       <ProjectCreatorForm />
       <PhaseBoard />
+      <PlanningGenerator />
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- add `generate` API route to call OpenAI using server-side `AI_API_KEY`
- create `PlanningGenerator` component that posts to the new route
- expose generator on the home page
- document `AI_API_KEY` usage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684eb841d5088320a89f55401a59aca1