### PR TITLE
Add Clerk provider and env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 # API key for your preferred AI service (e.g. OpenAI or Anthropic)
 # Used by the API route to call OpenAI or Gemini. Do not prefix with NEXT_PUBLIC
 AI_API_KEY=your-ai-api-key
+
+# Clerk authentication keys
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=your-clerk-publishable-key
+CLERK_SECRET_KEY=your-clerk-secret-key

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project is expected to run on a Next.js + Supabase stack. To work with the 
 - pnpm or npm for installing dependencies
 - Access to a Supabase project
 - API keys for any integrated AI services (provided via environment variables)
+- A Clerk account and API keys for authentication
 
 After cloning, install dependencies and set up your environment variables in a local `.env` file before running the development server. See `.env.example` for the required variable names.
 
@@ -29,6 +30,9 @@ NEXT_PUBLIC_SUPABASE_URL=<your-supabase-url>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-key>
 # API key for your preferred AI service (used server-side only)
 AI_API_KEY=<your-ai-api-key>
+# Clerk authentication keys
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=<your-clerk-publishable-key>
+CLERK_SECRET_KEY=<your-clerk-secret-key>
 ```
 
 ## Development

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,10 @@
 import type { AppProps } from 'next/app'
+import { ClerkProvider } from '@clerk/nextjs'
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <ClerkProvider>
+      <Component {...pageProps} />
+    </ClerkProvider>
+  )
 }


### PR DESCRIPTION
## Summary
- integrate `ClerkProvider` in `_app.tsx`
- add Clerk keys to `.env.example`
- document Clerk setup and variables in `README`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684ee53b8f808320b48e51f2a6c2337a