### PR TITLE
Add npm install and test info

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,21 @@ npm run dev
 
 The application uses the Next.js `pages/` directory. Reusable UI components live in `components/` and helper functions are in `lib/`.
 
+
+## Using npm scripts
+
+Before running `npm run dev`, `npm run lint`, or invoking the TypeScript compiler with `npx tsc`, make sure you have installed all project dependencies:
+
+```bash
+npm install
+```
+
+This step sets up the `node_modules` directory and ensures the development server, linters and TypeScript all function correctly.
+
+## Testing
+
+Automated tests are not included yet. Once a Jest configuration is added, you will be able to run the suite with:
+
+```bash
+npm test
+```


### PR DESCRIPTION
## Summary
- document that you must run `npm install` before running `npm run dev`, `npm run lint`, or `npx tsc`
- note that tests are not yet included and how to run them once available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684ee5375a948320a0da8a9a29874ea9