### PR TITLE
Remove apikeys file and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ Thumbs.db
 
 # Vercel
 .vercel/
+# Local API key file (should never be committed)
 apikeys.txt

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ This project is expected to run on a Next.js + Supabase stack. To work with the 
 - API keys for any integrated AI services (provided via environment variables)
 - A Clerk account and API keys for authentication
 
-After cloning, install dependencies and set up your environment variables in a local `.env` file before running the development server. See `.env.example` for the required variable names.
+After cloning, install dependencies and set up your environment variables in a `.env.local` file before running the development server. Use `.env.example` as a reference for the required variable names.
 
 ## Environment Variables
 
-Create a `.env` file in the project root with the following variables:
+Create a `.env.local` file in the project root with the following variables:
 
 ```bash
 NEXT_PUBLIC_SUPABASE_URL=<your-supabase-url>
@@ -32,12 +32,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-key>
 # API keys for AI providers
 OPENAI_API_KEY=<your-openai-api-key>
 ANTHROPIC_API_KEY=<your-anthropic-api-key>
-=======
 # API key for your preferred AI service (used server-side only)
 AI_API_KEY=<your-ai-api-key>
 # Clerk authentication keys
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=<your-clerk-publishable-key>
 CLERK_SECRET_KEY=<your-clerk-secret-key>
+```
 
 
 ## Development


### PR DESCRIPTION
## Summary
- document using `.env.local` to store API keys
- note that `apikeys.txt` should never be committed

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ef2a9ac988320b7ab2d649d10dc5f