### PR TITLE
Connect PlanningGenerator save flow

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,11 @@
 import PhaseBoard from '../components/planner/PhaseBoard'
 import { ProjectCreatorForm } from '../components/planner/ProjectCreatorForm'
-import PlanningGenerator from '../components/planner/PlanningGenerator'
 
 export default function Home() {
   return (
     <main className="p-6 space-y-6">
       <ProjectCreatorForm />
       <PhaseBoard />
-      <PlanningGenerator />
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- ensure `PlanningGenerator` is only used when a project id is available by removing it from the home page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ef2ac5810832091757cf966c39ea0