### PR TITLE
Add planning API route and integrate

### DIFF
--- a/components/planner/PlanningGenerator.tsx
+++ b/components/planner/PlanningGenerator.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { saveProjectArtifacts } from '../../lib/api/saveProjectArtifacts'
+import { getProjectById, Project } from '../../lib/projects'
 
 interface PlanningGeneratorProps {
-  projectId: string
+  projectId?: string
 }
 
 export default function PlanningGenerator({ projectId }: PlanningGeneratorProps) {
@@ -10,9 +11,24 @@ export default function PlanningGenerator({ projectId }: PlanningGeneratorProps)
   const [techStack, setTechStack] = useState('')
   const [promptPack, setPromptPack] = useState('')
   const [saving, setSaving] = useState(false)
+  const [generating, setGenerating] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [project, setProject] = useState<Project | null>(null)
+
+  useEffect(() => {
+    if (!projectId) return
+    ;(async () => {
+      try {
+        const p = await getProjectById(projectId)
+        setProject(p)
+      } catch (err) {
+        console.error(err)
+      }
+    })()
+  }, [projectId])
 
   async function handleSave() {
+    if (!projectId) return
     setSaving(true)
     setError(null)
     try {
@@ -27,6 +43,36 @@ export default function PlanningGenerator({ projectId }: PlanningGeneratorProps)
       setError(err.message)
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function handleGenerate() {
+    if (!project) return
+    setGenerating(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/generate-planning', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          projectName: project.name,
+          projectDescription: project.description,
+          aiTool: project.ai_tool,
+        }),
+      })
+
+      const data = await response.json()
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to generate')
+      }
+
+      setPrd(data.prd || data.text || '')
+      setTechStack(data.techStack || '')
+      setPromptPack(data.promptPack || '')
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setGenerating(false)
     }
   }
 
@@ -50,9 +96,18 @@ export default function PlanningGenerator({ projectId }: PlanningGeneratorProps)
         placeholder="Prompt Pack"
         className="w-full border rounded p-2"
       />
+      {project && (
+        <button
+          onClick={handleGenerate}
+          disabled={generating}
+          className="rounded bg-green-600 text-white px-4 py-2"
+        >
+          {generating ? 'Generating...' : 'Generate with AI'}
+        </button>
+      )}
       <button
         onClick={handleSave}
-        disabled={saving}
+        disabled={saving || !projectId}
         className="rounded bg-blue-600 text-white px-4 py-2"
       >
         {saving ? 'Saving...' : 'Save'}

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -7,6 +7,14 @@ export interface NewProject {
   aiTool: string;
 }
 
+export interface Project {
+  id: string
+  user_id: string
+  name: string
+  description: string
+  ai_tool: string
+}
+
 export async function createProject(project: NewProject) {
   const { data, error } = await supabase
     .from('projects')
@@ -25,4 +33,19 @@ export async function createProject(project: NewProject) {
   }
 
   return data;
+}
+
+export async function getProjectById(id: string) {
+  const { data, error } = await supabase
+    .from('projects')
+    .select('*')
+    .eq('id', id)
+    .single()
+
+  if (error) {
+    console.error('getProjectById error:', error.message)
+    throw new Error(error.message)
+  }
+
+  return data as Project
 }

--- a/pages/api/generate-planning.ts
+++ b/pages/api/generate-planning.ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { projectName, projectDescription, aiTool } = req.body as {
+    projectName?: string
+    projectDescription?: string
+    aiTool?: string
+  }
+
+  if (!projectName || !projectDescription) {
+    return res
+      .status(400)
+      .json({ error: 'projectName and projectDescription are required' })
+  }
+
+  try {
+    const apiKey = process.env.AI_API_KEY
+    if (!apiKey) {
+      throw new Error('AI_API_KEY not set')
+    }
+
+    const prompt = `You are an experienced product planner. Based on the project name "${projectName}" and the description below, generate a product requirements document (PRD), a recommended tech stack and a short prompt pack for the chosen AI tool ${aiTool ?? ''}. Respond in JSON with keys prd, techStack and promptPack.\n\n${projectDescription}`
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4-turbo',
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    })
+
+    if (!response.ok) {
+      const errText = await response.text()
+      console.error('OpenAI error:', errText)
+      return res.status(500).json({ error: 'OpenAI API error' })
+    }
+
+    const data = await response.json()
+    const text = data.choices?.[0]?.message?.content ?? ''
+
+    // Try parsing JSON response
+    try {
+      const json = JSON.parse(text)
+      return res.status(200).json(json)
+    } catch {
+      return res.status(200).json({ text })
+    }
+  } catch (err) {
+    console.error('Planning generation error:', err)
+    return res.status(500).json({ error: 'Failed to generate planning' })
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/generate-planning` route that calls OpenAI using env vars
- expose `getProjectById` helper for fetching project details
- extend `PlanningGenerator` to generate via the new API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ef2adc5d0832084390fa8c76b7eb7