### PR TITLE
Fix README links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Project Pilot is an AI-native platform that helps developers build software incr
 
 The repository includes two key documents that describe the vision and minimal viable product (MVP):
 
-- [`docs/ProjectPilot_Codex_ProjectDescription.md`](docs/ProjectPilot_Codex_ProjectDescription.md) – High level overview and philosophy of Project Pilot.
-- [`docs/ProjectPilot_Mvp_Prd.md`](docs/ProjectPilot_Mvp_Prd.md) – Product requirements for the v0.1 MVP release.
+- [ProjectPilot Codex Project Description](docs/ProjectPilot_Codex_ProjectDescription.md) – High level overview and philosophy of Project Pilot.
+- [ProjectPilot MVP PRD](docs/ProjectPilot_Mvp_Prd.md) – Product requirements for the v0.1 MVP release.
 
 These documents shape development by framing the product vision and clarifying the MVP feature set.
 
@@ -34,7 +34,6 @@ NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=<your-clerk-publishable-key>
 CLERK_SECRET_KEY=<your-clerk-secret-key>
 ```
 
-```
 
 
 ## Development


### PR DESCRIPTION
## Summary
- update README to use friendly text linking to docs/ProjectPilot_Codex_ProjectDescription.md and docs/ProjectPilot_Mvp_Prd.md
- remove stray code fence

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68516ee19c448320863e8e413274d8fb