### PR TITLE
Add project_artifacts schema and connect planner saving

### DIFF
--- a/components/planner/PlanningGenerator.tsx
+++ b/components/planner/PlanningGenerator.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react";
+import { getProjectById } from "@/lib/projects";
+import { saveProjectArtifacts } from "@/lib/api/saveProjectArtifacts";
 import {
   Card,
   CardContent,
@@ -33,11 +35,29 @@ async function generateContent(prompt: string) {
   return data.choices?.[0]?.message?.content?.trim() || "";
 }
 
-export default function PlanningGenerator({ project }: { project: Project }) {
+export default function PlanningGenerator({
+  projectId,
+}: {
+  projectId: string;
+}) {
+  const [project, setProject] = useState<Project | null>(null);
   const [prd, setPrd] = useState("");
   const [techStack, setTechStack] = useState("");
   const [promptPack, setPromptPack] = useState("");
   const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchProject() {
+      if (!projectId) return;
+      try {
+        const data = await getProjectById(projectId);
+        setProject(data);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchProject();
+  }, [projectId]);
 
   useEffect(() => {
     async function generate() {
@@ -69,9 +89,13 @@ export default function PlanningGenerator({ project }: { project: Project }) {
     generate();
   }, [project]);
 
-  function handleSave(section: "prd" | "stack" | "prompts") {
-    // TODO: connect to Supabase
-    console.log("save", section);
+  function handleSave() {
+    saveProjectArtifacts({
+      projectId,
+      prd,
+      techStack,
+      promptPack,
+    }).catch((err) => console.error(err));
   }
 
   return (
@@ -92,7 +116,7 @@ export default function PlanningGenerator({ project }: { project: Project }) {
           )}
         </CardContent>
         <CardFooter>
-          <Button onClick={() => handleSave("prd")}>Save Changes</Button>
+          <Button onClick={handleSave}>Save Changes</Button>
         </CardFooter>
       </Card>
 
@@ -111,7 +135,7 @@ export default function PlanningGenerator({ project }: { project: Project }) {
           )}
         </CardContent>
         <CardFooter>
-          <Button onClick={() => handleSave("stack")}>Save Changes</Button>
+          <Button onClick={handleSave}>Save Changes</Button>
         </CardFooter>
       </Card>
 
@@ -131,7 +155,7 @@ export default function PlanningGenerator({ project }: { project: Project }) {
           )}
         </CardContent>
         <CardFooter>
-          <Button onClick={() => handleSave("prompts")}>Save Changes</Button>
+          <Button onClick={handleSave}>Save Changes</Button>
         </CardFooter>
       </Card>
 

--- a/docs/project_artifacts.sql
+++ b/docs/project_artifacts.sql
@@ -1,0 +1,14 @@
+-- SQL schema for project_artifacts table
+-- This table stores generated planning artifacts for each project.
+-- One row per project is maintained via a unique project_id.
+
+CREATE TABLE IF NOT EXISTS project_artifacts (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  project_id uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  prd text,
+  tech_stack text,
+  prompt_pack text,
+  inserted_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT project_artifacts_project_id_key UNIQUE (project_id)
+);


### PR DESCRIPTION
## Summary
- add SQL schema for new `project_artifacts` table
- update `PlanningGenerator` to fetch project info and save artifacts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68516ee52eac83209510c3765ea452a8