### PR TITLE
Add dashboard and project pages

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -1,0 +1,8 @@
+export default function Dashboard() {
+  return (
+    <main className="p-6 space-y-2">
+      <h1 className="text-xl font-semibold">Dashboard</h1>
+      <p>This page will be protected with Clerk once authentication is configured.</p>
+    </main>
+  )
+}

--- a/pages/project/[id].tsx
+++ b/pages/project/[id].tsx
@@ -1,0 +1,17 @@
+import { useRouter } from 'next/router'
+import PhaseBoard from '../../components/planner/PhaseBoard'
+import PlanningGenerator from '../../components/planner/PlanningGenerator'
+
+export default function ProjectPage() {
+  const router = useRouter()
+  const { id } = router.query
+
+  if (!id) return null
+
+  return (
+    <main className="p-6 space-y-6">
+      <PhaseBoard />
+      <PlanningGenerator projectId={id as string} />
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add placeholder dashboard
- add dynamic project page rendering the planning components

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6851753e96848320a3aa9534010e8ff3